### PR TITLE
Fix and enhance rake task

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -21,6 +21,10 @@ class Repo
     json["isArchived"]
   end
 
+  def fork?
+    json["isFork"]
+  end
+
   def has_contributing_guidelines?
     default_branch_has_file?("CONTRIBUTING.md")
   end
@@ -109,6 +113,7 @@ class Repo
             name
             url
             isArchived
+            isFork
             defaultBranchRef {
               target {
                 ... on Commit {

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -103,7 +103,7 @@ class Repo
       <<-GRAPHQL
     {
       organization(login: "dxw") {
-        repositories(first: 100, orderBy: { field: NAME, direction: ASC }#{", after: \"#{after}\"" if after}) {
+        repositories(privacy: PUBLIC, first: 100, orderBy: { field: NAME, direction: ASC }#{", after: \"#{after}\"" if after}) {
           nodes {
             id
             name

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -41,6 +41,15 @@ class Repo
     !has_contributing_pr? && !(has_code_of_conduct? && has_contributing_guidelines?)
   end
 
+  def can_be_written_to?(username: "dxw-rails-user")
+    permission_string = begin
+                          client.permission_level("dxw/#{name}", username).permission
+                        rescue Octokit::Forbidden => _e
+                          "none"
+                        end
+    %w[admin write].include?(permission_string)
+  end
+
   private
 
   def default_branch_has_file?(name)

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -13,6 +13,10 @@ class Repo
     json["url"]
   end
 
+  def html_url
+    json["html_url"]
+  end
+
   def archived?
     json["isArchived"]
   end

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -13,10 +13,6 @@ class Repo
     json["url"]
   end
 
-  def html_url
-    json["html_url"]
-  end
-
   def archived?
     json["isArchived"]
   end

--- a/app/views/repos/index.html.erb
+++ b/app/views/repos/index.html.erb
@@ -19,8 +19,13 @@
       <td>
         <% if repo.has_contributing_pr? %>
           <%= link_to("View existing pull request", repo.contributing_pr_link) %>
-        <% else %>
-          <%= link_to("Create pull request", repo_pull_requests_path(repo.name), method: :post) %>
+        <% elsif repo.needs_action? %>
+          <% if repo.can_be_written_to? %>
+            <%= link_to("Create pull request", repo_pull_requests_path(repo.name), method: :post) %>
+          <% else %>
+            Manual action neeeded: dxw-rails-user has no write permissions
+            <%= " (fork)" if repo.fork? %>
+          <% end %>
         <% end %>
       </td>
     </tr>

--- a/lib/tasks/repositories.rake
+++ b/lib/tasks/repositories.rake
@@ -13,10 +13,11 @@ namespace :repo do
 
       repos_needing_action += 1
       pull_request = PullRequestCreator.new(repo.name).open_pull_request unless dry_run
-      puts "Created pull request #{pull_request.inspect}"
+      puts "Created pull request #{pull_request&.html_url}"
       opened_prs += 1
     rescue => e
-      logger.error("Error creating pull request on #{repo.name}: #{e.messages}")
+      puts "Error! #{e.message} on #{repo.html_url}"
+      Rails.logger.error("Error creating pull request on #{repo.name}: #{e.message}")
     end
 
     puts "Found #{repos_needing_action} repos needing action."

--- a/lib/tasks/repositories.rake
+++ b/lib/tasks/repositories.rake
@@ -12,6 +12,11 @@ namespace :repo do
       next unless repo.needs_action?
 
       repos_needing_action += 1
+      if !repo.can_be_written_to?
+        puts "Manual action needed: dxw-rails-user cannot open a pull request for #{repo.name}."
+        next
+      end
+
       pull_request = PullRequestCreator.new(repo.name).open_pull_request unless dry_run
       puts "Created pull request #{pull_request&.html_url}"
       opened_prs += 1

--- a/lib/tasks/repositories.rake
+++ b/lib/tasks/repositories.rake
@@ -12,7 +12,7 @@ namespace :repo do
       next unless repo.needs_action?
 
       repos_needing_action += 1
-      if !repo.can_be_written_to?
+      unless repo.can_be_written_to?
         puts "Manual action needed: dxw-rails-user cannot open a pull request for #{repo.name}."
         next
       end

--- a/lib/tasks/repositories.rake
+++ b/lib/tasks/repositories.rake
@@ -18,14 +18,16 @@ namespace :repo do
       end
 
       pull_request = PullRequestCreator.new(repo.name).open_pull_request unless dry_run
-      puts "Created pull request #{pull_request&.html_url}"
-      opened_prs += 1
+      if pull_request
+        puts "Created pull request #{pull_request.html_url}"
+        opened_prs += 1
+      end
     rescue => e
-      puts "Error! #{e.message} on #{repo.html_url}"
+      puts "Error creating pull request on #{repo.url}: #{e.message}"
       Rails.logger.error("Error creating pull request on #{repo.name}: #{e.message}")
     end
 
     puts "Found #{repos_needing_action} repos needing action."
-    puts "Opened #{opened_prs}"
+    puts "Opened #{opened_prs}" unless dry_run
   end
 end

--- a/lib/tasks/repositories.rake
+++ b/lib/tasks/repositories.rake
@@ -6,7 +6,7 @@ namespace :repo do
     opened_prs = 0
 
     repos = Repo.non_archived
-    puts "Total #{repos.size}"
+    puts "Total non-archived public repos #{repos.size}"
 
     repos.each do |repo|
       next unless repo.needs_action?

--- a/spec/features/list_repos_spec.rb
+++ b/spec/features/list_repos_spec.rb
@@ -1,6 +1,6 @@
-include GithubStubRequests
-
 feature "Viewing a list of public repos" do
+  include GithubStubRequests
+
   let(:fake_github_client) { double(:client) }
   let(:fake_permission) { double(:permission, permission: permission_level) }
   let(:permission_level) { "write" }

--- a/spec/features/list_repos_spec.rb
+++ b/spec/features/list_repos_spec.rb
@@ -1,5 +1,17 @@
+include GithubStubRequests
+
 feature "Viewing a list of public repos" do
+  let(:fake_github_client) { double(:client) }
+  let(:fake_permission) { double(:permission, permission: permission_level) }
+  let(:permission_level) { "write" }
+
   around(:each) { |example| VCR.use_cassette("repos", record: :new_episodes, &example) }
+
+  before do
+    stub_github_client
+    stub_pull_requests
+    stub_permission_check
+  end
 
   scenario "The user views the first page of public, non-archived repos" do
     visit root_path

--- a/spec/support/github_stub_requests.rb
+++ b/spec/support/github_stub_requests.rb
@@ -1,0 +1,19 @@
+module GithubStubRequests
+  def stub_github_client
+    allow(Octokit::Client).to receive(:new)
+      .and_return(fake_github_client)
+  end
+
+  def stub_pull_requests(pull_requests = [])
+    allow(fake_github_client).to receive(:pull_requests)
+      .and_return(pull_requests)
+  end
+
+  def stub_permission_check
+    allow(fake_github_client).to receive(:permission_level).and_return(fake_permission)
+  end
+
+  def stub_permission_forbidden
+    allow(fake_github_client).to receive(:permission_level).and_raise(Octokit::Forbidden)
+  end
+end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

* The rake task shows URLs for created PRs and repos with errors, and doesn’t count opened PRs for a dry run
* Query results are restricted to public repos instead of relying on the token's scope
* The view only shows relevant and possible actions for a repo, and surfaces information about the fork status of repos that the service account doesn't have write permissions for

## Screenshots of UI changes

### Before
<img width="1018" alt="Screenshot 2020-08-18 at 15 00 19" src="https://user-images.githubusercontent.com/579522/91300406-2088ba00-e79b-11ea-9194-cbf3024cd99f.png">

### After
<img width="1132" alt="Screenshot 2020-08-26 at 12 52 24" src="https://user-images.githubusercontent.com/579522/91300348-0e0e8080-e79b-11ea-8069-687d213a9a41.png">

## Next steps
