### PR TITLE
Replace deprecated gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 
 group :test do
   gem "capybara", ">= 2.15"
-  gem "chromedriver-helper"
+  gem "webdrivers", "~> 4.0"
   gem "selenium-webdriver"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,8 +58,6 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     ast (2.4.0)
     autoprefixer-rails (9.7.6)
       execjs
@@ -93,9 +91,6 @@ GEM
       terminal-table
       xpath (>= 2.1)
     childprocess (3.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.2)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -147,7 +142,6 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.7.1)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.4)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
@@ -316,6 +310,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -339,7 +337,6 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   capybara_table
-  chromedriver-helper
   coffee-rails (~> 5.0)
   database_cleaner
   dotenv-rails
@@ -372,6 +369,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   vcr
   web-console (>= 3.3.0)
+  webdrivers (~> 4.0)
   webmock
 
 RUBY VERSION


### PR DESCRIPTION
## Changes in this PR
Chromedriver-helper has been deprecated:
https://github.com/flavorjones/chromedriver-helper/issues/83

The recommended replacement is `webdrivers`:
https://github.com/titusfortner/webdrivers

## Screenshots of UI changes

No UI changes.